### PR TITLE
🔧【增强】：web_search 切换为智谱 MCP web-search-prime 联网搜索

### DIFF
--- a/src/lq/config.py
+++ b/src/lq/config.py
@@ -38,6 +38,7 @@ class APIConfig:
     base_url: str = "https://api.anthropic.com"
     api_key: str = ""
     proxy: str = ""  # HTTP/SOCKS 代理（如 socks5://127.0.0.1:1080）
+    mcp_key: str = ""  # 智谱 MCP API Key（联网搜索等），默认复用 api_key
 
 
 @dataclass
@@ -88,10 +89,12 @@ class LQConfig:
         cfg.active_hours = (ah[0], ah[1])
 
         api = d.get("api", {})
+        api_key = api.get("api_key", "")
         cfg.api = APIConfig(
             base_url=api.get("base_url", "https://api.anthropic.com"),
-            api_key=api.get("api_key", ""),
+            api_key=api_key,
             proxy=api.get("proxy", ""),
+            mcp_key=api.get("mcp_key", "") or api_key,
         )
 
         fs = d.get("feishu", {})
@@ -163,6 +166,7 @@ def load_from_env(env_path: Path) -> LQConfig:
         or vals.get("all_proxy")
         or ""
     )
+    cfg.api.mcp_key = vals.get("ZHIPU_API_KEY", "") or cfg.api.api_key
     cfg.feishu.app_id = vals.get("FEISHU_APP_ID", "")
     cfg.feishu.app_secret = vals.get("FEISHU_APP_SECRET", "")
     return cfg

--- a/src/lq/executor/api.py
+++ b/src/lq/executor/api.py
@@ -88,6 +88,7 @@ class DirectAPIExecutor:
 
     def __init__(self, api_config: APIConfig, model: str) -> None:
         self.model = model
+        self.mcp_key: str = api_config.mcp_key or api_config.api_key
         self.client = anthropic.AsyncAnthropic(
             api_key=api_config.api_key,
             base_url=api_config.base_url,


### PR DESCRIPTION
替换 DuckDuckGo + 百度 HTML 爬取方案为智谱 MCP 远程搜索服务：
- config.py: APIConfig 新增 mcp_key 字段，支持 ZHIPU_API_KEY 环境变量（默认复用 api_key）
- executor/api.py: DirectAPIExecutor 存储 mcp_key 供 router 访问
- router.py: 新增 _mcp_request / _ensure_mcp_session 实现 MCP Streamable HTTP 协议，
  _tool_web_search 改为调用 webSearchPrime 工具，支持 SSE 响应解析、会话缓存与自动重连

https://claude.ai/code/session_019vjBSCS8y3zk1YzXpvSVwH